### PR TITLE
feat: add navigation and breadcrumbs

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#1e80ff"/>
+  <text x="50" y="60" text-anchor="middle" font-size="50" fill="#fff" font-family="Arial">S</text>
+</svg>

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -16,3 +16,9 @@ button {
   font-family: inherit;
   cursor: pointer;
 }
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}

--- a/src/app/home.module.scss
+++ b/src/app/home.module.scss
@@ -3,15 +3,4 @@
 .home {
   padding: 2rem;
   text-align: center;
-
-  nav {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-
-    a {
-      color: $color-primary;
-    }
-  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Noto_Sans_SC } from "next/font/google";
 import "./globals.scss";
+import NavBar from "@/components/NavBar";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 const notoSans = Noto_Sans_SC({
   variable: "--font-sans",
@@ -18,7 +20,13 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="zh">
-      <body className={`${notoSans.variable} antialiased`}>{children}</body>
+      <body className={`${notoSans.variable} antialiased`}>
+        <NavBar />
+        <div className="container">
+          <Breadcrumbs />
+          <main>{children}</main>
+        </div>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,10 @@
-import Link from "next/link";
 import styles from "./home.module.scss";
 
 export default function Home() {
   return (
     <div className={styles.home}>
       <h1>Sass UI 示例</h1>
-      <nav>
-        <Link href="/dashboard">仪表盘</Link>
-        <Link href="/users">用户管理</Link>
-        <Link href="/orders">订单查询</Link>
-      </nav>
+      <p>欢迎使用演示系统</p>
     </div>
   );
 }

--- a/src/components/Breadcrumbs.module.scss
+++ b/src/components/Breadcrumbs.module.scss
@@ -1,0 +1,11 @@
+@use '../styles/variables' as *;
+
+.breadcrumbs {
+  font-size: 14px;
+  margin: 1rem 0;
+}
+
+.separator {
+  margin: 0 0.5rem;
+  color: #999;
+}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from './Breadcrumbs.module.scss';
+
+const nameMap: Record<string, string> = {
+  dashboard: '仪表盘',
+  users: '用户管理',
+  orders: '订单查询',
+};
+
+export default function Breadcrumbs() {
+  const pathname = usePathname();
+  const segments = pathname.split('/').filter(Boolean);
+
+  return (
+    <nav className={styles.breadcrumbs} aria-label="breadcrumb">
+      <Link href="/">首页</Link>
+      {segments.map((seg, i) => {
+        const href = '/' + segments.slice(0, i + 1).join('/');
+        return (
+          <span key={href}>
+            <span className={styles.separator}>/</span>
+            <Link href={href}>{nameMap[seg] ?? seg}</Link>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/NavBar.module.scss
+++ b/src/components/NavBar.module.scss
@@ -1,0 +1,29 @@
+@use '../styles/variables' as *;
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  color: $color-primary;
+}
+
+.menu {
+  display: flex;
+  gap: 1rem;
+}
+
+.search input {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import styles from './NavBar.module.scss';
+
+export default function NavBar() {
+  return (
+    <header className={styles.navbar}>
+      <div className={styles.logo}>
+        <Image src="/logo.svg" alt="SassUI" width={32} height={32} />
+        <span>SassUI</span>
+      </div>
+      <nav className={styles.menu}>
+        <Link href="/">首页</Link>
+        <Link href="/dashboard">仪表盘</Link>
+        <Link href="/users">用户管理</Link>
+        <Link href="/orders">订单查询</Link>
+      </nav>
+      <div className={styles.search}>
+        <input type="text" placeholder="搜索..." />
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add global navigation bar with logo, menu links, and search input
- include breadcrumb navigation and container layout
- tidy home page to rely on shared navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: To use Next.js' built-in Sass support, install `sass`; installation failed with 403)


------
https://chatgpt.com/codex/tasks/task_e_68a6de584380832e8845c9bedca2e7e8