### PR TITLE
fix: replace @apply usage to avoid unknown utility error

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,14 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Global resets without using Tailwind's @apply */
 body {
-  @apply m-0 bg-bg text-gray-800 font-sans;
+  margin: 0;
+  background-color: #f7f8fa;
+  color: #1f2937; /* tailwind text-gray-800 */
+  font-family: 'Noto Sans', 'Noto Sans CJK SC', sans-serif;
 }
 
 a {
-  @apply text-primary no-underline;
+  color: #1e80ff; /* tailwind primary */
+  text-decoration: none;
 }
 
 button {
-  @apply font-inherit cursor-pointer;
+  font: inherit;
+  cursor: pointer;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  content: ['./src/**/*.{ts,tsx}'],
+  // Include CSS files so that utilities used with `@apply` are recognized
+  content: ['./src/**/*.{ts,tsx,css}'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- avoid Tailwind `@apply` for global styles to prevent unknown utility errors
- scan CSS files in Tailwind content config

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Noto Sans SC` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e369b3f4832e824fb487ce312ad6