### PR TITLE
feat: add admin layout and components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_SC } from "next/font/google";
 import "./globals.css";
-import NavBar from "@/components/NavBar";
-import Breadcrumbs from "@/components/Breadcrumbs";
 
 const notoSans = Noto_Sans_SC({
   variable: "--font-sans",
@@ -21,11 +19,7 @@ export default function RootLayout({
   return (
     <html lang="zh">
       <body className={`${notoSans.variable} antialiased`}>
-        <NavBar />
-        <div className="mx-auto max-w-screen-xl p-4">
-          <Breadcrumbs />
-          <main>{children}</main>
-        </div>
+        <main>{children}</main>
       </body>
     </html>
   );

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -34,7 +34,7 @@ export default function Orders() {
             </>
           )}
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="secondary" onClick={() => setShowMore(!showMore)}>
+            <Button type="button" variant="default" onClick={() => setShowMore(!showMore)}>
               {showMore ? '隐藏高级' : '更多条件'}
             </Button>
             <Button type="submit">查询</Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import Layout from '@/components/Layout';
+import { MenuItem } from '@/components/Menu';
+import Button from '@/components/Button';
+import Card from '@/components/Card';
+import {
+  TextInput,
+  NumberInput,
+  PasswordInput,
+  SelectInput,
+  DateInput,
+  DateRangeInput,
+} from '@/components/Input';
+import Table, { Column } from '@/components/Table';
+
 export default function Home() {
+  const menuItems: MenuItem[] = [
+    { label: '仪表盘', href: '/dashboard' },
+    {
+      label: '用户管理',
+      children: [
+        { label: '用户列表', href: '/users' },
+        { label: '角色管理', href: '#' },
+      ],
+    },
+    {
+      label: '订单管理',
+      children: [{ label: '订单列表', href: '/orders' }],
+    },
+  ];
+
+  const columns: Column<{ name: string; age: number }>[] = [
+    { key: 'name', title: '姓名' },
+    { key: 'age', title: '年龄' },
+  ];
+  const data = [
+    { name: '张三', age: 28 },
+    { name: '李四', age: 32 },
+    { name: '王五', age: 26 },
+    { name: '赵六', age: 30 },
+  ];
+  const pageSize = 2;
+  const [page, setPage] = useState(1);
+  const paged = data.slice((page - 1) * pageSize, page * pageSize);
+
   return (
-    <div className="p-8 text-center">
-      <h1>Sass UI 示例</h1>
-      <p>欢迎使用演示系统</p>
-    </div>
+    <Layout menuItems={menuItems} header={<div className="font-bold">Sass UI Demo</div>}>
+      <Card title="按钮">
+        <div className="flex gap-2 flex-wrap">
+          <Button variant="primary">主按钮</Button>
+          <Button variant="default">默认按钮</Button>
+          <Button variant="success">成功按钮</Button>
+          <Button variant="warning">警告按钮</Button>
+          <Button variant="error">错误按钮</Button>
+          <Button variant="info">信息按钮</Button>
+        </div>
+      </Card>
+      <Card title="输入">
+        <div className="grid gap-2 grid-cols-1 md:grid-cols-2">
+          <TextInput placeholder="文本输入" />
+          <NumberInput placeholder="数字输入" />
+          <PasswordInput placeholder="密码输入" />
+          <SelectInput
+            options={[{ value: '', label: '请选择' }, { value: '1', label: '选项1' }]}
+          />
+          <DateInput />
+          <DateRangeInput />
+        </div>
+      </Card>
+      <Card title="表格">
+        <Table
+          columns={columns}
+          data={paged}
+          page={page}
+          pageSize={pageSize}
+          total={data.length}
+          onPageChange={setPage}
+        />
+      </Card>
+    </Layout>
   );
 }

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -29,8 +29,8 @@ export default function Users() {
             <td className="p-2 border-b">zhang@example.com</td>
             <td className="p-2 border-b">
               <div className="flex gap-2">
-                <Button variant="secondary" onClick={() => setShowEdit(true)}>修改</Button>
-                <Button variant="danger" onClick={() => setShowDelete(true)}>删除</Button>
+                <Button variant="default" onClick={() => setShowEdit(true)}>修改</Button>
+                <Button variant="error" onClick={() => setShowDelete(true)}>删除</Button>
               </div>
             </td>
           </tr>
@@ -60,7 +60,7 @@ export default function Users() {
       <Modal show={showDelete} title="删除用户" onClose={() => setShowDelete(false)}>
         <p>确定删除该用户吗？</p>
         <div className="flex justify-end">
-          <Button variant="danger" onClick={() => setShowDelete(false)}>删除</Button>
+          <Button variant="error" onClick={() => setShowDelete(false)}>删除</Button>
         </div>
       </Modal>
     </div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,15 +4,18 @@
 import { ButtonHTMLAttributes } from 'react';
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?: 'primary' | 'default' | 'warning' | 'success' | 'error' | 'info';
 };
 
 export default function Button({ variant = 'primary', className = '', ...props }: Props) {
-  const base = 'px-4 py-2 rounded text-white text-sm';
+  const base = 'px-4 py-2 rounded text-sm';
   const variants: Record<string, string> = {
-    primary: 'bg-primary',
-    secondary: 'bg-secondary',
-    danger: 'bg-danger',
+    primary: 'bg-primary text-white',
+    default: 'bg-default text-black',
+    warning: 'bg-warning text-white',
+    success: 'bg-success text-white',
+    error: 'bg-error text-white',
+    info: 'bg-info text-white',
   };
   return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function Card({ title, children }: Props) {
   return (
-    <div className="bg-white p-4 rounded-lg shadow mb-4">
+    <div className="bg-white p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow mb-4">
       {title && <h3 className="mt-0 mb-4 text-lg text-primary">{title}</h3>}
       {children}
     </div>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { InputHTMLAttributes, SelectHTMLAttributes } from 'react';
+
+const base = 'p-2 border border-gray-300 rounded w-full';
+
+export function TextInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="text" className={`${base} ${className}`} {...props} />;
+}
+
+export function NumberInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="number" className={`${base} ${className}`} {...props} />;
+}
+
+export function PasswordInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="password" className={`${base} ${className}`} {...props} />;
+}
+
+export function SelectInput({ options, className = '', ...props }: SelectHTMLAttributes<HTMLSelectElement> & { options: { value: string; label: string }[] }) {
+  return (
+    <select className={`${base} ${className}`} {...props}>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function DateInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="date" className={`${base} ${className}`} {...props} />;
+}
+
+export function DateRangeInput({
+  startProps = {},
+  endProps = {},
+}: {
+  startProps?: InputHTMLAttributes<HTMLInputElement>;
+  endProps?: InputHTMLAttributes<HTMLInputElement>;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <input type="date" className={base} {...startProps} />
+      <span>至</span>
+      <input type="date" className={base} {...endProps} />
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { ReactNode } from 'react';
+import Menu, { MenuItem } from './Menu';
+
+export function Header({ children }: { children: ReactNode }) {
+  return <div className="h-12 flex items-center px-4 border-b bg-white">{children}</div>;
+}
+
+export function Content({ children }: { children: ReactNode }) {
+  return <div className="flex-1 overflow-auto p-4 bg-bg">{children}</div>;
+}
+
+export default function Layout({
+  header,
+  menuItems,
+  children,
+}: {
+  header?: ReactNode;
+  menuItems: MenuItem[];
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-screen">
+      <Menu items={menuItems} />
+      <div className="flex-1 flex flex-col">
+        <Header>{header}</Header>
+        <Content>{children}</Content>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+export type MenuItem = {
+  label: string;
+  href?: string;
+  children?: MenuItem[];
+};
+
+function Item({ item, depth = 0 }: { item: MenuItem; depth?: number }) {
+  const [open, setOpen] = useState(false);
+  const hasChildren = item.children && item.children.length > 0;
+  return (
+    <div>
+      <div
+        className="p-2 cursor-pointer hover:bg-gray-100"
+        style={{ paddingLeft: depth * 16 }}
+        onClick={() => (hasChildren ? setOpen(!open) : undefined)}
+      >
+        {item.href ? <Link href={item.href}>{item.label}</Link> : item.label}
+      </div>
+      {hasChildren && open && (
+        <div>
+          {item.children!.map((child, idx) => (
+            <Item key={idx} item={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Menu({ items }: { items: MenuItem[] }) {
+  return (
+    <aside className="w-48 bg-white border-r h-screen overflow-auto">
+      {items.map((item, idx) => (
+        <Item key={idx} item={item} />
+      ))}
+    </aside>
+  );
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Button from './Button';
+
+export default function Pagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (p: number) => void;
+}) {
+  const totalPages = Math.ceil(total / pageSize);
+  return (
+    <div className="flex justify-end items-center gap-2 p-2 text-sm">
+      <Button
+        variant="default"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        className="px-2 py-1"
+      >
+        上一页
+      </Button>
+      <span>
+        {page} / {totalPages}
+      </span>
+      <Button
+        variant="default"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        className="px-2 py-1"
+      >
+        下一页
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { ReactNode } from 'react';
+import Pagination from './Pagination';
+
+export type Column<T> = {
+  key: keyof T;
+  title: ReactNode;
+};
+
+export default function Table<T extends Record<string, ReactNode>>({
+  columns,
+  data,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+}: {
+  columns: Column<T>[];
+  data: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (p: number) => void;
+}) {
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={String(col.key)} className="p-2 border-b bg-gray-50 text-left">
+                {col.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, idx) => (
+            <tr key={idx} className={idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+              {columns.map((col) => (
+                <td key={String(col.key)} className="p-2 border-b">
+                  {row[col.key] as ReactNode}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Pagination page={page} pageSize={pageSize} total={total} onPageChange={onPageChange} />
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,8 +7,11 @@ export default {
     extend: {
       colors: {
         primary: '#1e80ff',
-        secondary: '#13c2c2',
-        danger: '#ff4d4f',
+        default: '#d1d5db',
+        warning: '#faad14',
+        success: '#52c41a',
+        error: '#ff4d4f',
+        info: '#13c2c2',
         bg: '#f7f8fa',
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- add layout with header, menu and content for admin pages
- introduce button, input, card, table, and pagination components with consistent styles
- showcase all components on the demo page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e69bb600832eb873d581828d14d3