### PR TITLE
feat: refine floating island styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,33 +1,36 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
-/* Design tokens */
-:root {
-  --color-primary: theme("colors.primary");
-  --color-default: theme("colors.default");
-  --color-warning: theme("colors.warning");
-  --color-success: theme("colors.success");
-  --color-error: theme("colors.error");
-  --color-info: theme("colors.info");
-  --color-bg: theme("colors.bg");
-  --color-text: theme("colors.gray.800");
-}
+@layer base {
+  /* Design tokens */
+  :root {
+    --color-primary: theme("colors.primary");
+    --color-default: theme("colors.default");
+    --color-warning: theme("colors.warning");
+    --color-success: theme("colors.success");
+    --color-error: theme("colors.error");
+    --color-info: theme("colors.info");
+    --color-bg: theme("colors.bg");
+    --color-text: theme("colors.gray.800");
+    --spacing-unit: 8px;
+  }
 
-/* Global resets */
-body {
-  margin: 0;
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  font-family: var(--font-sans, 'Noto Sans', 'Noto Sans CJK SC', sans-serif);
-}
+  /* Global resets */
+  body {
+    margin: 0;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans, 'Noto Sans', 'Noto Sans CJK SC', sans-serif);
+    font-size: 14px;
+    line-height: 1.5;
+  }
 
-a {
-  color: var(--color-primary);
-  text-decoration: none;
-}
+  a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
 
-button {
-  font: inherit;
-  cursor: pointer;
+  button {
+    font: inherit;
+    cursor: pointer;
+  }
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,7 +9,7 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 export default function Button({ variant = 'primary', className = '', ...props }: Props) {
   const base =
-    'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 shadow-sm hover:shadow';
+    'inline-flex items-center justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium bg-white shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 hover:shadow-md focus:shadow-md';
   const variants: Record<string, string> = {
     primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
     default: 'bg-default text-black hover:bg-default/90 focus:ring-default',

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,7 +3,7 @@
 import { InputHTMLAttributes, SelectHTMLAttributes } from 'react';
 
 const base =
-  'w-full p-2 border border-gray-200 rounded-lg focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary shadow-inner';
+  'w-full p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm transition-shadow focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary hover:shadow-md focus:shadow-md';
 
 export function TextInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
   return <input type="text" className={`${base} ${className}`} {...props} />;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -15,7 +15,7 @@ export default function Pagination({
 }) {
   const totalPages = Math.ceil(total / pageSize);
   return (
-    <div className="flex justify-end items-center gap-2 p-2 text-sm bg-white rounded-lg shadow-sm">
+    <div className="flex justify-end items-center gap-2 p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm">
       <Button
         variant="default"
         disabled={page <= 1}


### PR DESCRIPTION
## Summary
- refactor global token and reset styles for Tailwind CSS v4
- align button, input and pagination components with 8px grid and shadow rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad64bb6c2c832ea20e60836e16a3f5