### PR TITLE
refine ui colors for demo

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,18 +4,9 @@
 
 
 @layer base {
-  /* 仅保留非 Tailwind 的自定义变量 */
+  /* 仅保留非 Tailwind 注入的自定义变量，避免覆盖颜色变量 */
   :root {
-    /* v4：从 Tailwind 注入的同名 CSS 变量取值 */
-    --color-primary: var(--color-primary);
-    --color-default: var(--color-default);
-    --color-warning: var(--color-warning);
-    --color-success: var(--color-success);
-    --color-error:   var(--color-error);
-    --color-info:    var(--color-info);
-    --color-bg:      var(--color-bg);
-    /* text 保留个回退，避免未定义时发灰 */
-    --color-text:    var(--color-text, var(--color-gray-800));
+    --color-text: var(--color-gray-800);
     --spacing-unit: 8px;
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,10 @@ export default function Home() {
   const paged = data.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <Layout menuItems={menuItems} header={<div className="font-bold">Sass UI Demo</div>}>
+    <Layout
+      menuItems={menuItems}
+      header={<div className="text-xl font-semibold text-gray-800">Sass UI Demo</div>}
+    >
       <Card title="按钮">
         <div className="flex gap-2 flex-wrap">
           <Button variant="primary">主按钮</Button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,7 +9,7 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 export default function Button({ variant = 'primary', className = '', ...props }: Props) {
   const base =
-    'inline-flex items-center justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium bg-white shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 hover:shadow-md focus:shadow-md';
+    'inline-flex items-center justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 hover:shadow-md focus:shadow-md';
   const variants: Record<string, string> = {
     primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
     default: 'bg-default text-black hover:bg-default/90 focus:ring-default',

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -12,7 +12,7 @@ export default function Card({ title, children, className = '' }: Props) {
       className={`mb-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md ${className}`}
     >
       {title && (
-        <h3 className="mt-0 mb-4 text-lg font-medium text-primary">{title}</h3>
+        <h3 className="mt-0 mb-4 text-lg font-medium text-gray-800">{title}</h3>
       )}
       {children}
     </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import Menu, { MenuItem } from './Menu';
 
 export function Header({ children }: { children: ReactNode }) {
   return (
-    <div className="h-12 flex items-center px-4 border-b bg-white shadow-sm">
+    <div className="h-12 flex items-center px-4 border-b border-gray-200 bg-white shadow-sm">
       {children}
     </div>
   );

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -15,7 +15,7 @@ function Item({ item, depth = 0 }: { item: MenuItem; depth?: number }) {
   return (
     <div>
       <div
-        className="p-2 rounded-lg cursor-pointer hover:bg-primary/10 transition-colors"
+        className="p-2 rounded-lg cursor-pointer hover:bg-primary/10 transition-colors text-gray-800"
         style={{ paddingLeft: depth * 16 + 8 }}
         onClick={() => (hasChildren ? setOpen(!open) : undefined)}
       >
@@ -34,7 +34,7 @@ function Item({ item, depth = 0 }: { item: MenuItem; depth?: number }) {
 
 export default function Menu({ items }: { items: MenuItem[] }) {
   return (
-    <aside className="w-48 bg-white border-r shadow-sm h-screen overflow-auto p-2 space-y-2">
+    <aside className="w-48 bg-primary/5 border-r border-gray-200 shadow-sm h-screen overflow-auto p-2 space-y-2">
       {items.map((item, idx) => (
         <Item key={idx} item={item} />
       ))}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -29,7 +29,7 @@ export default function Table<T extends Record<string, ReactNode>>({
         <thead>
           <tr>
             {columns.map((col) => (
-              <th key={String(col.key)} className="border-b bg-gray-50 p-2 text-left">
+              <th key={String(col.key)} className="border-b border-gray-200 bg-gray-50 p-2 text-left">
                 {col.title}
               </th>
             ))}
@@ -39,7 +39,7 @@ export default function Table<T extends Record<string, ReactNode>>({
           {data.map((row, idx) => (
             <tr key={idx} className={idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
               {columns.map((col) => (
-                <td key={String(col.key)} className="p-2 border-b">
+                <td key={String(col.key)} className="p-2 border-b border-gray-200">
                   {row[col.key] as ReactNode}
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- fix button background so default state uses theme colors
- restyle card headers and table borders for softer tone
- add subtle theming to navigation and header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad704e3928832e9ef4101293894520