### PR TITLE
style: refresh sidebar navigation theme

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,16 +3,22 @@
 import Card from "@/components/Card";
 import Grid from "@/components/Grid";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import Layout from "@/components/Layout";
+import { menuItems, footerItems } from "@/components/menuItems";
 
 export default function Dashboard() {
   return (
-    <>
+    <Layout
+      menuItems={menuItems}
+      footerItems={footerItems}
+      header={<div className="text-xl font-semibold text-gray-800">仪表盘</div>}
+    >
       <Breadcrumbs />
       <Grid cols={3} gap={2} className="max-md:grid-cols-2">
         <Card title="今日访问量">1,234</Card>
         <Card title="新增用户">56</Card>
         <Card title="订单总数">789</Card>
       </Grid>
-    </>
+    </Layout>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,5 @@
 import type { Metadata } from "next";
-import { Noto_Sans_SC } from "next/font/google";
 import "./globals.css";
-
-const notoSans = Noto_Sans_SC({
-  variable: "--font-sans",
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-});
 
 export const metadata: Metadata = {
   title: "Sass UI Demo",
@@ -18,7 +11,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="zh">
-      <body className={`${notoSans.variable} antialiased`}>
+      <body className="font-sans antialiased">
         <main>{children}</main>
       </body>
     </html>

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -11,11 +11,17 @@ import {
   SelectInput,
   DateInput,
 } from '@/components/Input';
+import Layout from '@/components/Layout';
+import { menuItems, footerItems } from '@/components/menuItems';
 
 export default function Orders() {
   const [showMore, setShowMore] = useState(false);
   return (
-    <>
+    <Layout
+      menuItems={menuItems}
+      footerItems={footerItems}
+      header={<div className="text-xl font-semibold text-gray-800">订单管理</div>}
+    >
       <Breadcrumbs />
       <h2 className="mb-4">订单查询</h2>
       <Card>
@@ -48,6 +54,6 @@ export default function Orders() {
           </div>
         </form>
       </Card>
-    </>
+    </Layout>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Layout from '@/components/Layout';
-import { MenuItem } from '@/components/Menu';
+import { menuItems, footerItems } from '@/components/menuItems';
 import Button from '@/components/Button';
 import Card from '@/components/Card';
 import {
@@ -17,21 +17,6 @@ import Table, { Column } from '@/components/Table';
 import Alert from '@/components/Alert';
 
 export default function Home() {
-  const menuItems: MenuItem[] = [
-    { label: '仪表盘', href: '/dashboard' },
-    {
-      label: '用户管理',
-      children: [
-        { label: '用户列表', href: '/users' },
-        { label: '角色管理', href: '#' },
-      ],
-    },
-    {
-      label: '订单管理',
-      children: [{ label: '订单列表', href: '/orders' }],
-    },
-  ];
-
   const columns: Column<{ name: string; age: number }>[] = [
     { key: 'name', title: '姓名' },
     { key: 'age', title: '年龄' },
@@ -49,6 +34,7 @@ export default function Home() {
   return (
     <Layout
       menuItems={menuItems}
+      footerItems={footerItems}
       header={<div className="text-xl font-semibold text-gray-800">Sass UI Demo</div>}
     >
       <Card title="按钮">

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -7,11 +7,14 @@ import Card from '@/components/Card';
 import Table, { Column } from '@/components/Table';
 import { TextInput } from '@/components/Input';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import Layout from '@/components/Layout';
+import { menuItems, footerItems } from '@/components/menuItems';
 
 interface UserRow {
   username: string;
   email: string;
   actions: ReactNode;
+  [key: string]: ReactNode;
 }
 
 export default function Users() {
@@ -43,14 +46,18 @@ export default function Users() {
   ];
 
   return (
-    <>
+    <Layout
+      menuItems={menuItems}
+      footerItems={footerItems}
+      header={<div className="text-xl font-semibold text-gray-800">用户管理</div>}
+    >
       <Breadcrumbs />
       <div className="flex justify-between items-center mb-4">
         <h2>用户管理</h2>
         <Button onClick={() => setShowAdd(true)}>新增用户</Button>
       </div>
       <Card>
-        <Table
+        <Table<UserRow>
           columns={columns}
           data={data}
           page={1}
@@ -88,7 +95,7 @@ export default function Users() {
           </Button>
         </div>
       </Modal>
-    </>
+    </Layout>
   );
 }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,15 +18,17 @@ export function Content({ children }: { children: ReactNode }) {
 export default function Layout({
   header,
   menuItems,
+  footerItems,
   children,
 }: {
   header?: ReactNode;
   menuItems: MenuItem[];
+  footerItems?: MenuItem[];
   children: ReactNode;
 }) {
   return (
     <div className="flex h-screen">
-      <Menu items={menuItems} />
+      <Menu items={menuItems} footerItems={footerItems} />
       <div className="flex-1 flex flex-col">
         <Header>{header}</Header>
         <Content>{children}</Content>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,30 +1,77 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { useState, ReactNode } from 'react';
 
 export type MenuItem = {
   label: string;
   href?: string;
+  icon?: ReactNode;
   children?: MenuItem[];
 };
 
-function Item({ item, depth = 0 }: { item: MenuItem; depth?: number }) {
-  const [open, setOpen] = useState(false);
+function Item({
+  item,
+  depth = 0,
+  collapsed,
+}: {
+  item: MenuItem;
+  depth?: number;
+  collapsed: boolean;
+}) {
+  const pathname = usePathname();
   const hasChildren = item.children && item.children.length > 0;
+  const childActive = hasChildren
+    ? item.children!.some((c) => (c.href ? pathname.startsWith(c.href) : false))
+    : false;
+  const active = item.href ? pathname.startsWith(item.href) : childActive;
+  const [open, setOpen] = useState(childActive);
+
+  const baseClass =
+    `flex items-center gap-2 p-2 rounded-lg transition-colors ${
+      active
+        ? 'bg-primary text-white border-l-4 border-primary'
+        : `text-gray-300 hover:bg-sidebar-hover hover:text-white ${
+            depth === 0 ? 'font-semibold text-gray-200' : ''
+          }`
+    }`;
+  const padding = { paddingLeft: depth * 16 + 8 };
+
+  const content = (
+    <>
+      {item.icon && <span className="w-5 h-5 flex items-center justify-center">{item.icon}</span>}
+      {!collapsed && <span>{item.label}</span>}
+    </>
+  );
+
+  if (item.href && !hasChildren) {
+    return (
+      <Link
+        href={item.href}
+        className={`${baseClass} cursor-pointer`}
+        style={padding}
+        title={collapsed && depth === 0 ? item.label : undefined}
+      >
+        {content}
+      </Link>
+    );
+  }
+
   return (
     <div>
       <div
-        className="p-2 rounded-lg cursor-pointer hover:bg-primary/10 transition-colors text-gray-800"
-        style={{ paddingLeft: depth * 16 + 8 }}
+        className={`${baseClass} cursor-pointer`}
+        style={padding}
         onClick={() => (hasChildren ? setOpen(!open) : undefined)}
+        title={collapsed && depth === 0 ? item.label : undefined}
       >
-        {item.href ? <Link href={item.href}>{item.label}</Link> : item.label}
+        {content}
       </div>
-      {hasChildren && open && (
+      {hasChildren && open && !collapsed && (
         <div>
           {item.children!.map((child, idx) => (
-            <Item key={idx} item={child} depth={depth + 1} />
+            <Item key={idx} item={child} depth={depth + 1} collapsed={collapsed} />
           ))}
         </div>
       )}
@@ -32,12 +79,37 @@ function Item({ item, depth = 0 }: { item: MenuItem; depth?: number }) {
   );
 }
 
-export default function Menu({ items }: { items: MenuItem[] }) {
+export default function Menu({
+  items,
+  footerItems = [],
+}: {
+  items: MenuItem[];
+  footerItems?: MenuItem[];
+}) {
+  const [collapsed, setCollapsed] = useState(false);
   return (
-    <aside className="w-48 bg-primary/5 border-r border-gray-200 shadow-sm h-screen overflow-auto p-2 space-y-2">
-      {items.map((item, idx) => (
-        <Item key={idx} item={item} />
-      ))}
+    <aside
+      className={`flex flex-col h-screen border-r border-gray-700 shadow-lg bg-sidebar text-gray-100 transition-all ${
+        collapsed ? 'w-16' : 'w-56'
+      }`}
+    >
+      <div className="flex-1 overflow-auto p-2 space-y-1">
+        {items.map((item, idx) => (
+          <Item key={idx} item={item} collapsed={collapsed} />
+        ))}
+      </div>
+      <div className="p-2 space-y-1 border-t border-gray-700">
+        {footerItems.map((item, idx) => (
+          <Item key={idx} item={item} collapsed={collapsed} />
+        ))}
+        <button
+          className="w-full text-left p-2 rounded-lg text-gray-300 hover:bg-sidebar-hover hover:text-white"
+          onClick={() => setCollapsed(!collapsed)}
+          title={collapsed ? '展开菜单' : '收起菜单'}
+        >
+          {collapsed ? '›' : '‹'}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/src/components/menuItems.ts
+++ b/src/components/menuItems.ts
@@ -1,0 +1,19 @@
+import { MenuItem } from './Menu';
+
+export const menuItems: MenuItem[] = [
+  { label: '仪表盘', href: '/dashboard', icon: '📊' },
+  {
+    label: '管理',
+    icon: '🛠️',
+    children: [
+      { label: '用户管理', href: '/users', icon: '👤' },
+      { label: '订单管理', href: '/orders', icon: '🧾' },
+    ],
+  },
+];
+
+export const footerItems: MenuItem[] = [
+  { label: '设置', href: '#', icon: '⚙️' },
+  { label: '帮助', href: '#', icon: '❓' },
+  { label: '退出登录', href: '#', icon: '🚪' },
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,8 @@ export default {
         error:   '#ff4d4f',
         info:    '#13c2c2',
         bg:      '#f7f8fa',
+        sidebar: '#1f2937',
+        'sidebar-hover': '#374151',
       },
       fontFamily: {
         sans: ['Noto Sans', 'Noto Sans CJK SC', 'sans-serif'],


### PR DESCRIPTION
## Summary
- apply dark-themed sidebar with distinct hover and active styles
- add `sidebar` color tokens and drop remote font dependency
- fix user table typing to allow successful build
- make entire sidebar row clickable and auto-expand active groups

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad73faf230832ea974fd9fd5287032