### PR TITLE
feat: improve navigation bar styling

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -27,8 +27,8 @@ function Item({
   return (
     <div>
       <div
-        className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors text-gray-800 hover:bg-primary/10 ${
-          active ? 'bg-primary text-white border-l-4 border-primary' : ''
+        className={`flex items-center gap-2 p-2 rounded-md cursor-pointer transition-colors text-gray-300 hover:bg-nav-hover hover:text-white ${
+          active ? 'bg-primary text-white shadow-md' : ''
         }`}
         style={{ paddingLeft: depth * 16 + 8 }}
         onClick={() => (hasChildren ? setOpen(!open) : undefined)}
@@ -58,7 +58,7 @@ export default function Menu({
   const [collapsed, setCollapsed] = useState(false);
   return (
     <aside
-      className={`flex flex-col h-screen border-r border-gray-200 shadow-sm bg-[#f4f6f8] transition-all ${
+      className={`flex flex-col h-screen border-r border-gray-700 shadow-lg bg-nav text-gray-200 transition-all ${
         collapsed ? 'w-16' : 'w-56'
       }`}
     >
@@ -67,12 +67,12 @@ export default function Menu({
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}
       </div>
-      <div className="p-2 space-y-1 border-t border-gray-200">
+      <div className="p-2 space-y-1 border-t border-gray-700">
         {footerItems.map((item, idx) => (
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}
         <button
-          className="w-full text-left p-2 rounded-lg hover:bg-primary/10"
+          className="w-full text-left p-2 rounded-md text-gray-300 hover:bg-nav-hover hover:text-white"
           onClick={() => setCollapsed(!collapsed)}
           title={collapsed ? '展开菜单' : '收起菜单'}
         >

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -4,19 +4,22 @@ import { TextInput } from './Input';
 
 export default function NavBar() {
   return (
-    <header className="flex items-center justify-between bg-white px-4 py-2 border-b shadow-sm">
-      <div className="flex items-center gap-2 font-bold text-primary">
+    <header className="flex items-center justify-between bg-nav px-4 py-2 border-b border-gray-700 shadow-md">
+      <div className="flex items-center gap-2 font-bold text-white">
         <Image src="/logo.svg" alt="SassUI" width={32} height={32} />
         <span>SassUI</span>
       </div>
-      <nav className="flex gap-4">
-        <Link href="/">首页</Link>
-        <Link href="/dashboard">仪表盘</Link>
-        <Link href="/users">用户管理</Link>
-        <Link href="/orders">订单查询</Link>
+      <nav className="flex gap-4 text-gray-300">
+        <Link className="px-2 py-1 rounded-md hover:bg-nav-hover hover:text-white transition-colors" href="/">首页</Link>
+        <Link className="px-2 py-1 rounded-md hover:bg-nav-hover hover:text-white transition-colors" href="/dashboard">仪表盘</Link>
+        <Link className="px-2 py-1 rounded-md hover:bg-nav-hover hover:text-white transition-colors" href="/users">用户管理</Link>
+        <Link className="px-2 py-1 rounded-md hover:bg-nav-hover hover:text-white transition-colors" href="/orders">订单查询</Link>
       </nav>
       <div>
-        <TextInput placeholder="搜索..." className="h-8 w-48" />
+        <TextInput
+          placeholder="搜索..."
+          className="h-8 w-48 bg-nav-hover text-gray-100 placeholder-gray-400 border border-nav-hover focus:border-primary focus:ring-1 focus:ring-primary"
+        />
       </div>
     </header>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,8 @@ export default {
         error:   '#ff4d4f',
         info:    '#13c2c2',
         bg:      '#f7f8fa',
+        nav: '#1f2937',
+        'nav-hover': '#374151',
       },
       fontFamily: {
         sans: ['Noto Sans', 'Noto Sans CJK SC', 'sans-serif'],


### PR DESCRIPTION
## Summary
- redesign navigation bar with dark theme and layered hover states
- add navigation-specific colors to tailwind config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a43d8c4832eba4878f0fcf78f18