### PR TITLE
feat: refine sidebar, inputs and table for floating island design

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,7 +3,7 @@
 import { InputHTMLAttributes, SelectHTMLAttributes } from 'react';
 
 const base =
-  'w-full p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm transition-shadow focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary hover:shadow-md focus:shadow-md';
+  'w-full p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm transition-shadow placeholder-gray-400 focus:outline-none focus:border-primary hover:shadow-md focus:shadow-md';
 
 export function TextInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
   return <input type="text" className={`${base} ${className}`} {...props} />;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,7 @@ export function Header({ children }: { children: ReactNode }) {
 }
 
 export function Content({ children }: { children: ReactNode }) {
-  return <div className="flex-1 overflow-auto p-4 bg-bg">{children}</div>;
+  return <div className="flex-1 overflow-auto p-6 bg-bg">{children}</div>;
 }
 
 export default function Layout({

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -27,8 +27,10 @@ function Item({
   return (
     <div>
       <div
-        className={`flex items-center gap-2 px-2 py-2 cursor-pointer transition-colors rounded-lg border border-gray-200 bg-white shadow-sm text-gray-700 hover:bg-gray-50 hover:shadow-md ${
-          active ? 'bg-primary/10 border-primary text-primary shadow-md' : ''
+        className={`flex items-center gap-2 px-2 py-2 cursor-pointer transition-colors rounded-lg ${
+          active
+            ? 'bg-nav-hover text-white shadow-md'
+            : 'text-gray-300 hover:bg-nav-hover hover:text-white'
         }`}
         style={{ paddingLeft: depth * 16 + 8 }}
         onClick={() => (hasChildren ? setOpen(!open) : undefined)}
@@ -58,7 +60,7 @@ export default function Menu({
   const [collapsed] = useState(false);
   return (
     <aside
-      className={`flex flex-col h-screen border-r border-gray-200 bg-bg p-2 transition-all ${
+      className={`flex flex-col h-screen border-r border-nav-deep bg-nav p-2 text-gray-200 transition-all ${
         collapsed ? 'w-16' : 'w-56'
       }`}
     >
@@ -67,7 +69,7 @@ export default function Menu({
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}
       </div>
-      <div className="pt-2 mt-2 border-t border-gray-200 space-y-2">
+      <div className="pt-2 mt-2 border-t border-nav-hover space-y-2">
         {footerItems.map((item, idx) => (
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -18,7 +18,7 @@ export default function NavBar() {
       <div>
         <TextInput
           placeholder="搜索..."
-          className="h-8 w-48 bg-nav-sub text-gray-100 placeholder-gray-400 border border-nav-hover focus:border-primary focus:ring-1 focus:ring-primary"
+          className="h-8 w-48 bg-nav-sub text-gray-100 placeholder-gray-400 border border-nav-hover focus:border-primary"
         />
       </div>
     </header>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -29,7 +29,10 @@ export default function Table<T extends Record<string, ReactNode>>({
         <thead>
           <tr>
             {columns.map((col) => (
-              <th key={String(col.key)} className="border-b border-gray-200 bg-gray-50 p-2 text-left">
+              <th
+                key={String(col.key)}
+                className="bg-gray-50 px-4 py-2 text-left border-b border-l border-gray-200 first:border-l-0"
+              >
                 {col.title}
               </th>
             ))}
@@ -39,7 +42,10 @@ export default function Table<T extends Record<string, ReactNode>>({
           {data.map((row, idx) => (
             <tr key={idx} className={idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
               {columns.map((col) => (
-                <td key={String(col.key)} className="p-2 border-b border-gray-200">
+                <td
+                  key={String(col.key)}
+                  className="px-4 py-2 border-b border-l border-gray-200 first:border-l-0"
+                >
                   {row[col.key] as ReactNode}
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- adopt dark palette for sidebar navigation
- soften input placeholders and simplify focus borders
- add column borders and spacing to table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6af1fe0832e9b167582e74ccd5e