### PR TITLE
Refine UI components with floating island design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
       header={<div className="text-xl font-semibold text-gray-800">Sass UI Demo</div>}
     >
       <Card title="按钮">
-        <div className="flex gap-2 flex-wrap">
+        <div className="flex flex-wrap gap-3">
           <Button variant="primary">主按钮</Button>
           <Button variant="default">默认按钮</Button>
           <Button variant="success">成功按钮</Button>
@@ -48,15 +48,28 @@ export default function Home() {
         </div>
       </Card>
       <Card title="输入">
-        <div className="grid gap-2 grid-cols-1 md:grid-cols-2">
-          <TextInput placeholder="文本输入" />
-          <NumberInput placeholder="数字输入" />
-          <PasswordInput placeholder="密码输入" />
-          <SelectInput
-            options={[{ value: '', label: '请选择' }, { value: '1', label: '选项1' }]}
-          />
-          <DateInput />
-          <DateRangeInput />
+        <div className="grid grid-cols-12 gap-4 md:gap-6">
+          <div className="col-span-12 md:col-span-6">
+            <TextInput label="文本输入" placeholder="请输入文本" />
+          </div>
+          <div className="col-span-12 md:col-span-6">
+            <NumberInput label="数字输入" placeholder="请输入数字" />
+          </div>
+          <div className="col-span-12 md:col-span-6">
+            <PasswordInput label="密码输入" placeholder="请输入密码" />
+          </div>
+          <div className="col-span-12 md:col-span-6">
+            <SelectInput
+              label="选择输入"
+              options={[{ value: '', label: '请选择' }, { value: '1', label: '选项1' }]}
+            />
+          </div>
+          <div className="col-span-12 md:col-span-6">
+            <DateInput label="日期输入" />
+          </div>
+          <div className="col-span-12 md:col-span-6">
+            <DateRangeInput label="日期范围" />
+          </div>
         </div>
       </Card>
       <Card title="表格">
@@ -70,7 +83,7 @@ export default function Home() {
         />
       </Card>
       <Card title="提示">
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col space-y-3">
           <Alert variant="success">操作成功</Alert>
           <Alert variant="warning">警告信息</Alert>
           <Alert variant="error">错误信息</Alert>

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 // Alert 组件用于展示全局提示信息
 export default function Alert({
@@ -12,16 +12,25 @@ export default function Alert({
   className?: string;
   children: ReactNode;
 }) {
-  const base = 'p-4 rounded-lg border shadow-sm';
+  const [open, setOpen] = useState(true);
+  if (!open) return null;
+  const base = 'relative flex items-start p-4 rounded-lg';
   const variants: Record<string, string> = {
-    success: 'bg-success text-white border-success',
-    warning: 'bg-warning text-white border-warning',
-    error: 'bg-error text-white border-error',
-    info: 'bg-info text-white border-info',
+    success: 'bg-success/10 border-l-4 border-success text-success/90',
+    warning: 'bg-warning/10 border-l-4 border-warning text-warning/90',
+    error: 'bg-error/10 border-l-4 border-error text-error/90',
+    info: 'bg-info/10 border-l-4 border-info text-info/90',
   };
   return (
     <div role="alert" className={`${base} ${variants[variant]} ${className}`}>
-      {children}
+      <div className="flex-1">{children}</div>
+      <button
+        onClick={() => setOpen(false)}
+        className="ml-4 text-gray-400 hover:text-gray-600"
+        aria-label="关闭"
+      >
+        ×
+      </button>
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,18 +5,33 @@ import { ButtonHTMLAttributes } from 'react';
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'default' | 'warning' | 'success' | 'error' | 'info';
+  outline?: boolean;
 };
 
-export default function Button({ variant = 'primary', className = '', ...props }: Props) {
+export default function Button({
+  variant = 'primary',
+  outline = false,
+  className = '',
+  ...props
+}: Props) {
   const base =
-    'inline-flex items-center justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 hover:shadow-md focus:shadow-md';
-  const variants: Record<string, string> = {
-    primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
-    default: 'bg-default text-black hover:bg-default/90 focus:ring-default',
-    warning: 'bg-warning text-white hover:bg-warning/90 focus:ring-warning',
-    success: 'bg-success text-white hover:bg-success/90 focus:ring-success',
-    error: 'bg-error text-white hover:bg-error/90 focus:ring-error',
-    info: 'bg-info text-white hover:bg-info/90 focus:ring-info',
+    'inline-flex h-9 items-center justify-center rounded-lg px-4 text-sm font-medium shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 ring-offset-2 ring-offset-white hover:shadow-md active:shadow';
+  const solid: Record<string, string> = {
+    primary: 'border border-transparent bg-primary text-white focus-visible:ring-primary',
+    default: 'border border-transparent bg-default text-white focus-visible:ring-default',
+    warning: 'border border-transparent bg-warning text-white focus-visible:ring-warning',
+    success: 'border border-transparent bg-success text-white focus-visible:ring-success',
+    error: 'border border-transparent bg-error text-white focus-visible:ring-error',
+    info: 'border border-transparent bg-info text-white focus-visible:ring-info',
   };
+  const outlined: Record<string, string> = {
+    primary: 'border border-primary text-primary bg-white focus-visible:ring-primary',
+    default: 'border border-default text-default bg-white focus-visible:ring-default',
+    warning: 'border border-warning text-warning bg-white focus-visible:ring-warning',
+    success: 'border border-success text-success bg-white focus-visible:ring-success',
+    error: 'border border-error text-error bg-white focus-visible:ring-error',
+    info: 'border border-info text-info bg-white focus-visible:ring-info',
+  };
+  const variants = outline ? outlined : solid;
   return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -9,12 +9,16 @@ type Props = {
 export default function Card({ title, children, className = '' }: Props) {
   return (
     <div
-      className={`mb-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md ${className}`}
+      className={`rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md focus-within:shadow-md ${className}`}
     >
-      {title && (
-        <h3 className="mt-0 mb-4 text-lg font-medium text-gray-800">{title}</h3>
+      {title ? (
+        <>
+          <div className="px-6 pt-5 pb-3 text-gray-700 font-medium">{title}</div>
+          <div className="px-6 pb-6">{children}</div>
+        </>
+      ) : (
+        <div className="p-4 md:p-6">{children}</div>
       )}
-      {children}
     </div>
   );
 }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,48 +3,104 @@
 import { InputHTMLAttributes, SelectHTMLAttributes } from 'react';
 
 const base =
-  'w-full p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm transition-shadow placeholder-gray-400 focus:outline-none focus:border-primary hover:shadow-md focus:shadow-md';
+  'w-full h-10 rounded-lg border border-gray-200 px-3 text-sm placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/50 shadow-none';
 
-export function TextInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return <input type="text" className={`${base} ${className}`} {...props} />;
-}
+type InputProps = InputHTMLAttributes<HTMLInputElement> & { label?: string };
 
-export function NumberInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return <input type="number" className={`${base} ${className}`} {...props} />;
-}
-
-export function PasswordInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return <input type="password" className={`${base} ${className}`} {...props} />;
-}
-
-export function SelectInput({ options, className = '', ...props }: SelectHTMLAttributes<HTMLSelectElement> & { options: { value: string; label: string }[] }) {
+export function TextInput({ label, className = '', ...props }: InputProps) {
   return (
-    <select className={`${base} ${className}`} {...props}>
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <input type="text" className={`${base} ${className}`} {...props} />
+    </label>
   );
 }
 
-export function DateInput({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return <input type="date" className={`${base} ${className}`} {...props} />;
+export function NumberInput({ label, className = '', ...props }: InputProps) {
+  return (
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <input type="number" className={`${base} ${className}`} {...props} />
+    </label>
+  );
+}
+
+export function PasswordInput({ label, className = '', ...props }: InputProps) {
+  return (
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <input type="password" className={`${base} ${className}`} {...props} />
+    </label>
+  );
+}
+
+export function SelectInput({
+  options,
+  label,
+  className = '',
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement> & {
+  options: { value: string; label: string }[];
+  label?: string;
+}) {
+  return (
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <div className="relative">
+        <select
+          className={`${base} pr-10 appearance-none text-gray-500 ${className}`}
+          {...props}
+        >
+          {options.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">⌄</span>
+      </div>
+    </label>
+  );
+}
+
+export function DateInput({ label, className = '', ...props }: InputProps) {
+  return (
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <input
+        type="date"
+        className={`${base} text-gray-500 ${className}`}
+        {...props}
+      />
+    </label>
+  );
 }
 
 export function DateRangeInput({
   startProps = {},
   endProps = {},
+  label,
 }: {
   startProps?: InputHTMLAttributes<HTMLInputElement>;
   endProps?: InputHTMLAttributes<HTMLInputElement>;
+  label?: string;
 }) {
   return (
-    <div className="flex items-center gap-2">
-      <input type="date" className={base} {...startProps} />
-      <span>至</span>
-      <input type="date" className={base} {...endProps} />
-    </div>
+    <label className="block">
+      {label && <span className="mb-2 block text-xs text-gray-500">{label}</span>}
+      <div className="inline-flex items-center gap-2">
+        <input
+          type="date"
+          className={`${base} w-[180px] text-gray-500`}
+          {...startProps}
+        />
+        <span className="px-2 text-xs text-gray-500">至</span>
+        <input
+          type="date"
+          className={`${base} w-[180px] text-gray-500`}
+          {...endProps}
+        />
+      </div>
+    </label>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,14 +5,18 @@ import Menu, { MenuItem } from './Menu';
 
 export function Header({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center px-0 py-2 border-b border-gray-200 bg-white shadow-sm">
+    <div className="flex items-center px-6 py-2 border-b border-gray-200 bg-white shadow-sm">
       {children}
     </div>
   );
 }
 
 export function Content({ children }: { children: ReactNode }) {
-  return <div className="flex-1 overflow-auto p-6 bg-bg">{children}</div>;
+  return (
+    <div className="flex-1 overflow-auto bg-bg px-6 py-6">
+      <div className="mx-auto max-w-screen-2xl space-y-6">{children}</div>
+    </div>
+  );
 }
 
 export default function Layout({

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -27,10 +27,10 @@ function Item({
   return (
     <div>
       <div
-        className={`flex items-center gap-2 px-2 py-2 cursor-pointer transition-colors rounded-lg ${
+        className={`relative flex items-center gap-2 px-2 py-2 cursor-pointer transition-colors rounded-lg ${
           active
-            ? 'bg-nav-hover text-white shadow-md'
-            : 'text-gray-300 hover:bg-nav-hover hover:text-white'
+            ? 'bg-white/10 text-white before:absolute before:inset-y-1 before:left-0 before:w-1 before:bg-primary'
+            : 'text-gray-300 hover:bg-white/5'
         }`}
         style={{ paddingLeft: depth * 16 + 8 }}
         onClick={() => (hasChildren ? setOpen(!open) : undefined)}
@@ -69,7 +69,7 @@ export default function Menu({
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}
       </div>
-      <div className="pt-2 mt-2 border-t border-nav-hover space-y-2">
+      <div className="mt-6 border-t border-white/10 pt-4 space-y-2">
         {footerItems.map((item, idx) => (
           <Item key={idx} item={item} collapsed={collapsed} />
         ))}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -15,12 +15,13 @@ export default function Pagination({
 }) {
   const totalPages = Math.ceil(total / pageSize);
   return (
-    <div className="flex justify-end items-center gap-2 p-2 text-sm bg-white border border-gray-200 rounded-lg shadow-sm">
+    <div className="flex items-center space-x-2 text-sm">
       <Button
         variant="default"
+        outline
         disabled={page <= 1}
         onClick={() => onPageChange(page - 1)}
-        className="px-2 py-1"
+        className="h-9 px-3"
       >
         上一页
       </Button>
@@ -29,9 +30,10 @@ export default function Pagination({
       </span>
       <Button
         variant="default"
+        outline
         disabled={page >= totalPages}
         onClick={() => onPageChange(page + 1)}
-        className="px-2 py-1"
+        className="h-9 px-3"
       >
         下一页
       </Button>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -26,34 +26,49 @@ export default function Table<T extends Record<string, ReactNode>>({
   return (
     <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
       <table className="w-full border-collapse">
-        <thead>
+        <thead className="sticky top-0 z-10 bg-gray-50 text-gray-600">
           <tr>
             {columns.map((col) => (
-              <th
-                key={String(col.key)}
-                className="bg-gray-50 px-4 py-2 text-left border-b border-l border-gray-200 first:border-l-0"
-              >
+              <th key={String(col.key)} className="h-10 px-6 text-left">
                 {col.title}
               </th>
             ))}
           </tr>
         </thead>
-        <tbody>
-          {data.map((row, idx) => (
-            <tr key={idx} className={idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
-              {columns.map((col) => (
-                <td
-                  key={String(col.key)}
-                  className="px-4 py-2 border-b border-l border-gray-200 first:border-l-0"
-                >
-                  {row[col.key] as ReactNode}
-                </td>
-              ))}
+        <tbody className="divide-y divide-gray-200">
+          {data.length > 0 ? (
+            data.map((row, idx) => (
+              <tr
+                key={idx}
+                className="h-12 odd:bg-white even:bg-gray-50 hover:bg-primary/3"
+              >
+                {columns.map((col) => (
+                  <td key={String(col.key)} className="px-6">
+                    {row[col.key] as ReactNode}
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="py-10 text-center text-gray-400"
+              >
+                暂无数据
+              </td>
             </tr>
-          ))}
+          )}
         </tbody>
       </table>
-      <Pagination page={page} pageSize={pageSize} total={total} onPageChange={onPageChange} />
+      <div className="flex justify-end pt-4">
+        <Pagination
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={onPageChange}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Standardize layout spacing and card styling for 8px grid
- Add labeled form inputs, responsive table, and softer alerts
- Improve navigation and button states with consistent tokens
- Remove default outline from inputs and lighten select/date placeholders

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch `Noto Sans SC` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68aebae941dc832ebd23f78537181d93