### PR TITLE
feat: improve card header and button sizing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,13 +38,47 @@ export default function Home() {
       header={<div className="text-xl font-semibold text-gray-800">Sass UI Demo</div>}
     >
       <Card title="按钮">
-        <div className="flex flex-wrap gap-3">
-          <Button variant="primary">主按钮</Button>
-          <Button variant="default">默认按钮</Button>
-          <Button variant="success">成功按钮</Button>
-          <Button variant="warning">警告按钮</Button>
-          <Button variant="error">错误按钮</Button>
-          <Button variant="info">信息按钮</Button>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-wrap gap-3">
+            <Button size="large" variant="primary">
+              大按钮
+            </Button>
+            <Button size="large" variant="default">
+              大按钮
+            </Button>
+            <Button size="large" variant="success">
+              大按钮
+            </Button>
+            <Button size="large" variant="warning">
+              大按钮
+            </Button>
+            <Button size="large" variant="error">大按钮</Button>
+            <Button size="large" variant="info">大按钮</Button>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button variant="primary">中按钮</Button>
+            <Button variant="default">中按钮</Button>
+            <Button variant="success">中按钮</Button>
+            <Button variant="warning">中按钮</Button>
+            <Button variant="error">中按钮</Button>
+            <Button variant="info">中按钮</Button>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button size="small" variant="primary">
+              小按钮
+            </Button>
+            <Button size="small" variant="default">
+              小按钮
+            </Button>
+            <Button size="small" variant="success">
+              小按钮
+            </Button>
+            <Button size="small" variant="warning">
+              小按钮
+            </Button>
+            <Button size="small" variant="error">小按钮</Button>
+            <Button size="small" variant="info">小按钮</Button>
+          </div>
         </div>
       </Card>
       <Card title="输入">

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,16 +6,23 @@ import { ButtonHTMLAttributes } from 'react';
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'default' | 'warning' | 'success' | 'error' | 'info';
   outline?: boolean;
+  size?: 'large' | 'medium' | 'small';
 };
 
 export default function Button({
   variant = 'primary',
   outline = false,
+  size = 'medium',
   className = '',
   ...props
 }: Props) {
   const base =
-    'inline-flex h-9 items-center justify-center rounded-lg px-4 text-sm font-medium shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 ring-offset-2 ring-offset-white hover:shadow-md active:shadow';
+    'inline-flex items-center justify-center rounded-lg font-medium shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 ring-offset-2 ring-offset-white hover:shadow-md active:shadow';
+  const sizes: Record<string, string> = {
+    large: 'h-11 px-6 text-base',
+    medium: 'h-9 px-4 text-sm',
+    small: 'h-7 px-3 text-xs',
+  };
   const solid: Record<string, string> = {
     primary: 'border border-transparent bg-primary text-white focus-visible:ring-primary',
     default: 'border border-transparent bg-default text-white focus-visible:ring-default',
@@ -33,5 +40,10 @@ export default function Button({
     info: 'border border-info text-info bg-white focus-visible:ring-info',
   };
   const variants = outline ? outlined : solid;
-  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+  return (
+    <button
+      className={`${base} ${sizes[size]} ${variants[variant]} ${className}`}
+      {...props}
+    />
+  );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,16 +4,34 @@ type Props = {
   title?: string;
   children: ReactNode;
   className?: string;
+  closable?: boolean;
+  onClose?: () => void;
 };
 
-export default function Card({ title, children, className = '' }: Props) {
+export default function Card({
+  title,
+  children,
+  className = '',
+  closable = false,
+  onClose,
+}: Props) {
   return (
     <div
       className={`rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md focus-within:shadow-md ${className}`}
     >
       {title ? (
         <>
-          <div className="px-6 pt-5 pb-3 text-gray-700 font-medium">{title}</div>
+          <div className="flex justify-between items-center px-6 pt-5 pb-3">
+            <div className="text-gray-700 font-medium text-lg">{title}</div>
+            {closable && (
+              <button
+                onClick={onClose}
+                className="p-2 rounded-lg text-gray-500 hover:bg-gray-100"
+              >
+                ×
+              </button>
+            )}
+          </div>
           <div className="px-6 pb-6">{children}</div>
         </>
       ) : (


### PR DESCRIPTION
## Summary
- enlarge card header text and add optional close button
- support large, medium, and small button sizes and showcase them on demo page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aebfa7e7ac832eb3d279d9a9f651ef