### PR TITLE
fix: restore table header height

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -180,7 +180,6 @@ export default function Table<T extends Record<string, unknown>>({
           <thead
             className={[
               stickyHeader ? 'sticky top-0 z-10' : '',
-              sizeClass.th,
               'bg-gray-50 text-gray-700',
               'border-b border-gray-200',
               scrolled ? 'shadow-sm' : '',
@@ -201,7 +200,9 @@ export default function Table<T extends Record<string, unknown>>({
                     key={String(col.key)}
                     scope="col"
                     aria-sort={ariaSort}
-                    className={`font-medium text-gray-700 h-12 ${col.align === 'right' ? 'text-right' : 'text-left'}`}
+                    className={`${sizeClass.th} h-12 font-medium text-gray-700 ${
+                      col.align === 'right' ? 'text-right' : 'text-left'
+                    }`}
                     style={{ minWidth: col.minWidth, width: col.width }}
                   >
                     <button


### PR DESCRIPTION
## Summary
- keep table header at fixed `h-12` height while aligning padding with body cells

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Noto Sans SC` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68afd072c750832e82af24e26fdabb20